### PR TITLE
ARM64/dts: atoll: Disable pm8008

### DIFF
--- a/arch/arm64/boot/dts/qcom/atoll.dtsi
+++ b/arch/arm64/boot/dts/qcom/atoll.dtsi
@@ -4248,7 +4248,12 @@
 	vdd_l7-supply = <&BOB>;
 };
 
+&pm8008_8 {
+	status = "disabled";
+};
+
 &pm8008_9 {
+	status = "disabled";
 	/* GPIO1 pinctrl config */
 	pinctrl-names = "default";
 	pinctrl-0 = <&pm8008_gpio1_active>;


### PR DESCRIPTION
as i'm looking into it, ginkgo doesn't even use pm8008.

and since this caused lot's of demsg spam, disable it.
[    0.655485] i2c_pmic 0-0009: could not find pctldev for node /soc/i2c@4a84000/qcom,pm8008@8/pinctrl@c000/gpio1_active/pm8008_gpio1_active, deferring probe

Signed-off-by: Dede Dindin Qudsy <xtrymind@gmail.com>